### PR TITLE
Provide "my-default.cnf" to "mysql_install_db" from a different location.

### DIFF
--- a/src/main/java/com/jcabi/mysql/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/mysql/maven/plugin/Instances.java
@@ -245,15 +245,16 @@ public final class Instances {
     private File data(final File dist, final File target) throws IOException {
         final File dir = new File(target, DATA_SUB_DIR);
         if (!dir.exists()) {
+            final File cnf = new File(target, "my-default.cnf");
             FileUtils.writeStringToFile(
-                new File(dist, "support-files/my-default.cnf"),
+                cnf,
                 "[mysql]\n# no defaults..."
             );
             new VerboseProcess(
                 this.builder(
                     dist,
                     "scripts/mysql_install_db",
-                    Instances.NO_DEFAULTS,
+                    String.format("--defaults-file=%s", cnf),
                     "--force",
                     "--innodb_use_native_aio=0",
                     String.format("--datadir=%s", dir),


### PR DESCRIPTION
At the moment the "my-default.cnf" file gets overwritten in the "support-files" folder of the provided MySQL distribution. This can be inconvenient in an environment where a user (or build system) does not have write access to the folder of the installed MySQL.

To get over this problem I used to copy the entire MySQL distribution into target. This is a time consuming and unnecessary step as the "mysql_install_db" allows to take a "my-default.cnf" from a different location using the "--defaults-file" parameter.
