### PR TITLE
Report error

### DIFF
--- a/src/main/java/com/jcabi/mysql/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/mysql/maven/plugin/Instances.java
@@ -279,7 +279,7 @@ public final class Instances {
                     String.format("--datadir=%s", dir),
                     String.format("--basedir=%s", dist)
                 )
-            ).stdoutQuietly();
+            ).stdout();
         }
         return dir;
     }
@@ -352,7 +352,7 @@ public final class Instances {
                 "password",
                 Instances.DEFAULT_PASSWORD
             )
-        ).stdoutQuietly();
+        ).stdout();
         final Process process =
             this.builder(
                 dist,
@@ -389,7 +389,7 @@ public final class Instances {
             );
         }
         writer.close();
-        new VerboseProcess(process).stdoutQuietly();
+        new VerboseProcess(process).stdout();
     }
 
     /**


### PR DESCRIPTION
Why hide errors? For example i had an issue with too long socket, i had no error when starting my instance