### PR TITLE
Wait a bit, otherwise the socket is created before complete initializ…

### DIFF
--- a/src/main/java/com/jcabi/mysql/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/mysql/maven/plugin/Instances.java
@@ -79,6 +79,11 @@ public final class Instances {
     private static final String NO_DEFAULTS = "--no-defaults";
 
     /**
+     * Default retry count.
+     */
+    private static final int RETRY_COUNT = 5;
+
+    /**
      * Default user.
      */
     private static final String DEFAULT_USER = "root";
@@ -345,6 +350,7 @@ public final class Instances {
                 dist,
                 "bin/mysqladmin",
                 Instances.NO_DEFAULTS,
+                String.format("--wait=%d", Instances.RETRY_COUNT),
                 String.format("--port=%d", config.port()),
                 String.format("--user=%s", Instances.DEFAULT_USER),
                 String.format("--socket=%s", socket),


### PR DESCRIPTION
Maybe there is a better way. I have a random issue with the mysql jcabi. The mysqladmin script runs just after can't connect to the database. If i put a breakpoint on the error and try to run again on terminal the command it works well. Is there a small gap between the socket file creation and the connection availability? 