### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Build Status](https://travis-ci.org/jcabi/jcabi-mysql-maven-plugin.svg?branch=master)](https://travis-ci.org/jcabi/jcabi-mysql-maven-plugin)
 [![PDD status](http://www.0pdd.com/svg?name=jcabi/jcabi-mysql-maven-plugin)](http://www.0pdd.com/p?name=jcabi/jcabi-mysql-maven-plugin)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-mysql-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-mysql-maven-plugin)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jcabi/jcabi-mysql-maven-plugin/badge.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-mysql-maven-plugin)
+[![Javadoc](https://javadoc.io/badge/com.jcabi/jcabi-mysql-maven-plugin.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-mysql-maven-plugin)
 [![Build status](https://ci.appveyor.com/api/projects/status/3axyj0ho4xjc5i5k)](https://ci.appveyor.com/project/yegor256/jcabi-mysql-maven-plugin)
 
 More details are here: [mysql.jcabi.com](http://mysql.jcabi.com/index.html)


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io